### PR TITLE
Add `auth` option passthrough to `Req`

### DIFF
--- a/lib/druid/client.ex
+++ b/lib/druid/client.ex
@@ -40,6 +40,7 @@ defmodule Druid.Client do
       |> put_present(:plug, Keyword.get(opts, :plug))
       |> put_present(:adapter, Keyword.get(opts, :adapter))
       |> put_present(:finch, Keyword.get(opts, :finch))
+      |> put_present(:auth, Keyword.get(opts, :auth))
 
     response = Req.request!(request, request_opts)
 

--- a/lib/druid/client.ex
+++ b/lib/druid/client.ex
@@ -41,6 +41,7 @@ defmodule Druid.Client do
       |> put_present(:adapter, Keyword.get(opts, :adapter))
       |> put_present(:finch, Keyword.get(opts, :finch))
       |> put_present(:auth, Keyword.get(opts, :auth))
+      |> put_present(:receive_timeout, Keyword.get(opts, :timeout))
 
     response = Req.request!(request, request_opts)
 

--- a/lib/druid/client.ex
+++ b/lib/druid/client.ex
@@ -6,7 +6,7 @@ defmodule Druid.Client do
   @default_scheme "http"
 
   defmodule RequestError do
-    defexception [:message]
+    defexception [:message, :response]
   end
 
   @doc """
@@ -51,7 +51,8 @@ defmodule Druid.Client do
 
       code when code in 400..599 ->
         raise RequestError,
-              "Error (#{response.status}) when querying Druid.\n\t#{inspect(response.body)}"
+          message: "Error (#{response.status}) when querying Druid.\n\t#{inspect(response.body)}",
+          response: response
 
       _ ->
         raise RuntimeError,

--- a/lib/ecto/adapters/druid.ex
+++ b/lib/ecto/adapters/druid.ex
@@ -28,7 +28,7 @@ defmodule Ecto.Adapters.Druid do
 
       config :my_app, MyApp.Repo,
         host: "localhost",
-        port: 8082
+        port: 8082,
         finch_opts: [pools: %{default: [size: 10]}]
 
   The following options are supported:
@@ -36,6 +36,7 @@ defmodule Ecto.Adapters.Druid do
   * `:host` - The host of the Druid server.
   * `:port` - The port of the Druid server.
   * `:scheme` - The scheme of the Druid server (http or https).
+  * `:auth` - Authentication options. See `Req` documentation for details.
   * `:finch_opts` - [Options](https://hexdocs.pm/finch/Finch.html#start_link/1-options) to pass to Finch when making requests to Druid.
   """
 

--- a/lib/ecto/adapters/druid/types.ex
+++ b/lib/ecto/adapters/druid/types.ex
@@ -15,6 +15,7 @@ defmodule Ecto.Adapters.Druid.Types do
   def to_db(value) when is_float(value), do: db("DOUBLE", value)
   def to_db(value) when is_binary(value), do: db("VARCHAR", value)
   def to_db(value) when is_boolean(value), do: db("BOOLEAN", value)
+  def to_db(value) when is_list(value), do: db("ARRAY", value)
 
   defp db(type, value), do: %{type: type, value: value}
 end

--- a/lib/ecto/adapters/druid/types.ex
+++ b/lib/ecto/adapters/druid/types.ex
@@ -11,7 +11,7 @@ defmodule Ecto.Adapters.Druid.Types do
   def loaders(:complex, value), do: [:string, value]
   def loaders(type, value), do: [type, value]
 
-  def to_db(value) when is_integer(value), do: db("LONG", value)
+  def to_db(value) when is_integer(value), do: db("BIGINT", value)
   def to_db(value) when is_float(value), do: db("DOUBLE", value)
   def to_db(value) when is_binary(value), do: db("VARCHAR", value)
   def to_db(value) when is_boolean(value), do: db("BOOLEAN", value)

--- a/lib/ecto/druid/query.ex
+++ b/lib/ecto/druid/query.ex
@@ -802,6 +802,9 @@ defmodule Ecto.Druid.Query do
 
   # Array functions
 
+  @doc "Checks if the scalar value is present in the array. Returns false if the value is non-null, or UNKNOWN if the value is NULL. Returns UNKNOWN if the array is NULL."
+  sql_function scalar_in_array(expr, arr)
+
   @doc "Constructs a SQL ARRAY literal from the expression arguments, using the type of the first argument as the output array type."
   sql_function array(exprs), wrapper: {"[", "]"}
 


### PR DESCRIPTION
This allows basic authorization to be specified for all requests:
```
auth: {:basic, "user:pass"}
```

Also fix `LONG` SQL type error.